### PR TITLE
Reduces idle check interval

### DIFF
--- a/YouTube/yt-toggle-autoplay-on-idle.user.js
+++ b/YouTube/yt-toggle-autoplay-on-idle.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         yt-toggle-autoplay-on-idle
 // @namespace    https://cybergene.dev/
-// @version      1.5.1
+// @version      1.6.0
 // @description  Stops YouTube autoplay after a period of inactivity
 // @match        https://www.youtube.com/watch?v=*
 // @match        https://www.youtube.com/shorts/*

--- a/YouTube/yt-toggle-autoplay-on-idle.user.js
+++ b/YouTube/yt-toggle-autoplay-on-idle.user.js
@@ -233,7 +233,7 @@
   /**
    * Periodically checks if the user has been inactive for longer than the threshold
    * If inactive and autoplay is enabled, turns off autoplay and shows notification
-   * Runs every 10 minutes (600,000 ms)
+   * Runs every 1 minute (60,000 ms)
    */
   setInterval(() => {
     const idleMs = Date.now() - lastActivity;
@@ -264,5 +264,5 @@
         showNotification(notificationMessage);
       }
     }
-  }, 600000);
+  }, 60000);
 })();


### PR DESCRIPTION
Decreases the interval for checking user inactivity from 10 minutes to 1 minute.

This change provides a more responsive experience by disabling autoplay more quickly when the user is idle.
5e4bf1