### PR TITLE
Updates match URL to include all watch pages

### DIFF
--- a/YouTube/yt-toggle-autoplay-on-idle.user.js
+++ b/YouTube/yt-toggle-autoplay-on-idle.user.js
@@ -3,7 +3,7 @@
 // @namespace    https://cybergene.dev/
 // @version      1.6.4
 // @description  Automatically turns off YouTube's autoplay feature after a configurable period of inactivity to prevent continuous playback when you're no longer watching
-// @match        https://www.youtube.com/watch?v*
+// @match        https://www.youtube.com/watch*
 // @match        https://www.youtube.com/shorts/*
 // @match        https://www.youtube.com/live/*
 // @grant        none

--- a/YouTube/yt-toggle-autoplay-on-idle.user.js
+++ b/YouTube/yt-toggle-autoplay-on-idle.user.js
@@ -1,9 +1,9 @@
 // ==UserScript==
 // @name         YouTube Auto-Toggle Autoplay on Idle
 // @namespace    https://cybergene.dev/
-// @version      1.6.3
+// @version      1.6.4
 // @description  Automatically turns off YouTube's autoplay feature after a configurable period of inactivity to prevent continuous playback when you're no longer watching
-// @match        https://www.youtube.com/watch?v=*
+// @match        https://www.youtube.com/watch?v*
 // @match        https://www.youtube.com/shorts/*
 // @match        https://www.youtube.com/live/*
 // @grant        none


### PR DESCRIPTION
This pull request makes a minor update to the YouTube Auto-Toggle Autoplay on Idle userscript. The main change is an improvement to the match pattern for YouTube video URLs to ensure the script runs on a broader set of video pages.

- Updated the `@match` pattern for YouTube video URLs from `https://www.youtube.com/watch?v=*` to `https://www.youtube.com/watch?v*` to cover more variations of video URLs.The previous match URL only matched `watch?v=*`,
but not `watch?v`.

This change updates it to `watch?v*` to ensure all YouTube watch pages are matched.