### PR TITLE
Updates version and fixes match URL

### DIFF
--- a/YouTube/yt-toggle-autoplay-on-idle.user.js
+++ b/YouTube/yt-toggle-autoplay-on-idle.user.js
@@ -1,9 +1,9 @@
 // ==UserScript==
 // @name         YouTube Auto-Toggle Autoplay on Idle
 // @namespace    https://cybergene.dev/
-// @version      1.6.4
+// @version      1.6.5
 // @description  Automatically turns off YouTube's autoplay feature after a configurable period of inactivity to prevent continuous playback when you're no longer watching
-// @match        https://www.youtube.com/watch*
+// @match        https://www.youtube.com/watch?v=*
 // @match        https://www.youtube.com/shorts/*
 // @match        https://www.youtube.com/live/*
 // @grant        none


### PR DESCRIPTION
This pull request makes a minor update to the YouTube Auto-Toggle Autoplay on Idle userscript, refining the script's URL matching behavior.

URL matching update:

* Updated the `@match` pattern in `YouTube/yt-toggle-autoplay-on-idle.user.js` to only match watch pages with a video ID, preventing the script from running on generic watch pages without a video.Updates the script version to 1.6.5.

Changes the match URL for youtube.com/watch to be more specific, matching only URLs with a "v" parameter to avoid incorrectly matching other watch-related pages.