### PR TITLE
fix(yt-autoplay): handle SPA navigation on YouTube (v1.7.0)

### DIFF
--- a/YouTube/yt-toggle-autoplay-on-idle.user.js
+++ b/YouTube/yt-toggle-autoplay-on-idle.user.js
@@ -244,7 +244,11 @@
 
   const isVideoPage = () => {
     const url = window.location.href;
-    return url.includes("/watch?v=") || url.includes("/shorts/") || url.includes("/live/");
+    return (
+      url.includes("/watch?v=") ||
+      url.includes("/shorts/") ||
+      url.includes("/live/")
+    );
   };
 
   // Dismiss notification when navigating away from a video page

--- a/YouTube/yt-toggle-autoplay-on-idle.user.js
+++ b/YouTube/yt-toggle-autoplay-on-idle.user.js
@@ -243,15 +243,15 @@
   };
 
   const isVideoPage = () => {
-    const url = window.location.href;
+    const { pathname, searchParams } = new URL(location.href);
     return (
-      url.includes("/watch?v=") ||
-      url.includes("/shorts/") ||
-      url.includes("/live/")
+      (pathname === "/watch" && searchParams.has("v")) ||
+      pathname.startsWith("/shorts/") ||
+      pathname.startsWith("/live/")
     );
   };
 
-  // Dismiss notification when navigating away from a video page
+  // Dismiss notification on any SPA navigation (covers video→video and video→non-video)
   document.addEventListener("yt-navigate-start", () => {
     if (currentNotification) {
       currentNotification.remove();

--- a/YouTube/yt-toggle-autoplay-on-idle.user.js
+++ b/YouTube/yt-toggle-autoplay-on-idle.user.js
@@ -1,11 +1,9 @@
 // ==UserScript==
 // @name         YouTube Auto-Toggle Autoplay on Idle
 // @namespace    https://cybergene.dev/
-// @version      1.6.6
+// @version      1.7.0
 // @description  Automatically turns off YouTube's autoplay feature after a configurable period of inactivity to prevent continuous playback when you're no longer watching
-// @match        https://www.youtube.com/watch?v=*
-// @match        https://www.youtube.com/shorts/*
-// @match        https://www.youtube.com/live/*
+// @match        https://www.youtube.com/*
 // @grant        none
 // @author       cybergene
 // @source       https://github.com/cyber-gene/UserScripts
@@ -244,6 +242,19 @@
     });
   };
 
+  const isVideoPage = () => {
+    const url = window.location.href;
+    return url.includes("/watch?v=") || url.includes("/shorts/") || url.includes("/live/");
+  };
+
+  // Dismiss notification when navigating away from a video page
+  document.addEventListener("yt-navigate-start", () => {
+    if (currentNotification) {
+      currentNotification.remove();
+      currentNotification = null;
+    }
+  });
+
   /**
    * Tracks the timestamp of the last user activity
    * Used to calculate idle duration
@@ -273,6 +284,8 @@
    * Runs every 1 minute (60,000 ms)
    */
   setInterval(() => {
+    if (!isVideoPage()) return;
+
     const idleMs = Date.now() - lastActivity;
     const idleThreshold = idleMinutes * 60 * 1000;
 


### PR DESCRIPTION
## Summary

- `@match` を `https://www.youtube.com/*` に統合し、ホームページなど動画以外のページでもスクリプトが起動するようにした
- `isVideoPage()` チェックを `setInterval` の先頭に追加し、動画ページ以外では処理をスキップするようにした
- `yt-navigate-start` イベントを監視し、動画ページを離れた際に残存通知を自動クローズするようにした

## 背景

YouTubeはSPAのため、ホームページから動画ページへの遷移はページの再ロードを伴わない。
従来の `@match` ディレクティブは初回ロード時のURLにのみ評価されるため、ホームページ起動後に動画ページへ遷移してもスクリプトが有効にならなかった。

## Test plan

- [ ] ホームページ (`youtube.com`) から動画ページへ遷移してスクリプトが動作することを確認
- [ ] 直接動画URLを開いた場合も従来通り動作することを確認
- [ ] Shorts・Live ページでも動作することを確認
- [ ] 動画ページから別ページへ移動した際に通知が自動的に閉じられることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)